### PR TITLE
Map data back to CPU to prevent numpy error

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -114,6 +114,6 @@ x = rearrange(x, "(b t) c h w -> b t h w c", t=total_frames)
 # save video
 x = torch.clamp(x, 0, 1)
 x = (x * 255).byte()
-write_video("video.mp4", x[0], fps=20)
+write_video("video.mp4", x[0].cpu(), fps=20)
 print("generation saved to video.mp4.")
 


### PR DESCRIPTION
Without this change, I get
```
    video_array = torch.as_tensor(video_array, dtype=torch.uint8).numpy()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```